### PR TITLE
Login adjustments

### DIFF
--- a/0.3.1/handlers/phpvms5/pilot/login.php
+++ b/0.3.1/handlers/phpvms5/pilot/login.php
@@ -19,11 +19,11 @@ assertData($_POST, array('password' => 'string'));
 
 if(strpos($_GET['username'], '@'))
 {
-    $result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rank, retired, confirmed, password, salt FROM ' . dbPrefix . 'pilots WHERE email=?', array($_GET['username']));
+    $result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rank, retired, confirmed, password, salt FROM ' . dbPrefix . 'pilots WHERE LOWER(email)=?', array(strtolower($_GET['username'])));
 }
 else
 {
-    $result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rank, retired, confirmed, password, salt FROM ' . dbPrefix . 'pilots WHERE pilotid=?', array($_GET['username']));
+    $result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rank, retired, confirmed, password, salt FROM ' . dbPrefix . 'pilots WHERE pilotid=?', array(preg_replace("/[^0-9]/","",$_GET['username'])));
 }
 
 if($result === array())

--- a/0.3.1/handlers/phpvms7/pilot/login.php
+++ b/0.3.1/handlers/phpvms7/pilot/login.php
@@ -19,11 +19,11 @@ assertData($_POST, array('password' => 'string'));
 
 if(strpos($_GET['username'], '@'))
 {
-    $user = $database->fetch('SELECT id, pilot_id as pilotid, name, avatar, email, password FROM ' . dbPrefix . 'users WHERE email=?', array($_GET['username']));
+    $user = $database->fetch('SELECT id, pilot_id as pilotid, name, avatar, email, password FROM ' . dbPrefix . 'users WHERE LOWER(email)=?', array(strtolower($_GET['username'])));
 }
 else
 {
-    $user = $database->fetch('SELECT id, pilot_id as pilotid, name, avatar, email, password FROM ' . dbPrefix . 'users WHERE pilot_id=?', array($_GET['username']));
+    $user = $database->fetch('SELECT id, pilot_id as pilotid, name, avatar, email, password FROM ' . dbPrefix . 'users WHERE pilot_id=?', array(preg_replace("/[^0-9]/","",$_GET['username'])));
 }
 
 if($user === array())


### PR DESCRIPTION
This PR introduces the below two items

- Case insensitive email login. 
typing `user@example.com` into the login form will now match `USER@example.com`

- Filtering out characters if not an email
Typing `QFA2066` into the login form will filter out the letters and will now successfully match `2066`  as the pilot id in the DB