### PR TITLE
Rename code to airlineCode

### DIFF
--- a/0.3.3/handlers/phpvms7/pireps/search.php
+++ b/0.3.3/handlers/phpvms7/pireps/search.php
@@ -1,7 +1,7 @@
 <?php
 $query = 'SELECT id,
 created_at as submitDate,
-(SELECT icao FROM ' . dbPrefix . 'airlines WHERE ' . dbPrefix . 'airlines.id=' . dbPrefix . 'pireps.airline_id) as code,
+(SELECT icao FROM ' . dbPrefix . 'airlines WHERE ' . dbPrefix . 'airlines.id=' . dbPrefix . 'pireps.airline_id) as airlineCode,
 flight_number as number,
 route,
 distance,


### PR DESCRIPTION
The `phpvms5` and `logbook` implementation both use `airlineCode` and not `code`