### PR TITLE
Fix landing rate display on phpvms7

### DIFF
--- a/0.3.3/handlers/phpvms7/pilot/statistics.php
+++ b/0.3.3/handlers/phpvms7/pilot/statistics.php
@@ -1,6 +1,6 @@
 <?php
 $pilotStatistics = $database->fetch('SELECT flight_time as totalhours, flights as totalflights FROM ' . dbPrefix . 'users WHERE pilot_id=?', array($pilotID));
-$pirepStatistics = $database->fetch('SELECT COALESCE(AVG(landing_rate), 0) AS landingRate FROM pireps WHERE user_id = ? AND state = 2 ORDER BY created_at DESC LIMIT 100', array($pilotID));
+$pirepStatistics = $database->fetch('SELECT COALESCE(AVG(landing_rate), 0) AS landingRate FROM pireps WHERE user_id = ? AND state = 2', array($pilotID));
 $pilotStatistics = $pilotStatistics[0];
 echo(json_encode(array(
     'hoursFlown' => $pilotStatistics['totalhours'] / 60,

--- a/0.3.3/handlers/phpvms7/pilot/statistics.php
+++ b/0.3.3/handlers/phpvms7/pilot/statistics.php
@@ -1,6 +1,6 @@
 <?php
 $pilotStatistics = $database->fetch('SELECT flight_time as totalhours, flights as totalflights FROM ' . dbPrefix . 'users WHERE pilot_id=?', array($pilotID));
-$pirepStatistics = $database->fetch('SELECT COALESCE(AVG(landing_rate), 0) AS landingRate FROM pireps WHERE user_id = ? AND state = 2', array($pilotID));
+$pirepStatistics = $database->fetch('SELECT COALESCE(AVG(landing_rate), 0) AS landingRate FROM pireps WHERE user_id = ? AND state = 2 ORDER BY created_at DESC LIMIT 100', array($pilotID));
 $pilotStatistics = $pilotStatistics[0];
 echo(json_encode(array(
     'hoursFlown' => $pilotStatistics['totalhours'] / 60,

--- a/0.3.3/handlers/phpvms7/pilot/statistics.php
+++ b/0.3.3/handlers/phpvms7/pilot/statistics.php
@@ -1,6 +1,6 @@
 <?php
 $pilotStatistics = $database->fetch('SELECT flight_time as totalhours, flights as totalflights FROM ' . dbPrefix . 'users WHERE pilot_id=?', array($pilotID));
-$pirepStatistics = $database->fetch('SELECT COALESCE(AVG(landing_rate), 0) AS landingRate from pireps WHERE user_id = ? AND state = 2', array($pilotID));
+$pirepStatistics = $database->fetch('SELECT COALESCE(AVG(landing_rate), 0) AS landingRate FROM pireps WHERE user_id = ? AND state = 2', array($pilotID));
 $pilotStatistics = $pilotStatistics[0];
 echo(json_encode(array(
     'hoursFlown' => $pilotStatistics['totalhours'] / 60,

--- a/0.3.3/handlers/phpvms7/pilot/statistics.php
+++ b/0.3.3/handlers/phpvms7/pilot/statistics.php
@@ -1,19 +1,11 @@
 <?php
 $pilotStatistics = $database->fetch('SELECT flight_time as totalhours, flights as totalflights FROM ' . dbPrefix . 'users WHERE pilot_id=?', array($pilotID));
-$pirepStatistics = $database->fetch('SELECT landing_rate as landingRate FROM ' . dbPrefix . 'pireps WHERE user_id=? and status = 2', array($pilotID));
+$pirepStatistics = $database->fetch('SELECT COALESCE(AVG(landing_rate), 0) AS landingRate from pireps WHERE user_id = ? AND state = 2', array($pilotID));
 $pilotStatistics = $pilotStatistics[0];
-$totalLandingRate = 0;
-if($pirepStatistics !== array())
-{
-    foreach($pirepStatistics as $pirep)
-    {
-        $totalLandingRate += $pirep['landingRate'];
-    }
-}
 echo(json_encode(array(
     'hoursFlown' => $pilotStatistics['totalhours'] / 60,
     'flightsFlown' => $pilotStatistics['totalflights'],
-    'averageLandingRate' => count($pirepStatistics) > 0 ? round($totalLandingRate/count($pirepStatistics)) : 0,
+    'averageLandingRate' => $pirepStatistics[0]['landingRate'],
     'pirepsFiled' => count($pirepStatistics),
 )));
 ?>


### PR DESCRIPTION
Previous code always returned 0 as we should check the `state` column instead of the `status` one.

Use the SQL `AVG` function to simplify the code. Also limit the request to the latest 100 pireps to prevent overloading the database for pilots with too many pireps.