### PR TITLE
Fixed SQL Queries Missing DB Prefixes

### DIFF
--- a/0.3.4/handlers/phpvms7/flights/bookings.php
+++ b/0.3.4/handlers/phpvms7/flights/bookings.php
@@ -4,21 +4,21 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 $schedules = $database->fetch(
-'SELECT bids.id as bidID,
-airlines.icao as code,
-flights.flight_number as number,
-flights.flight_type as type,
-flights.dpt_airport_id as departureAirport,
-flights.arr_airport_id as arrivalAirport,
-flights.route,
-flights.level as flightLevel,
-flights.distance,
-flights.dpt_time as departureTime,
-flights.arr_time as arrivalTime,
-flights.flight_time as flightTime,
-flights.days as daysOfWeek,
-flights.id as flightID,
-flights.notes FROM ' . dbPrefix . 'bids INNER JOIN ' . dbPrefix . 'flights ON bids.flight_id = flights.id INNER JOIN ' . dbPrefix . 'airlines ON flights.airline_id = airlines.id WHERE ' . dbPrefix . 'bids.user_id=?',
+'SELECT ' . dbPrefix . 'bids.id as bidID,
+' . dbPrefix . 'airlines.icao as code,
+' . dbPrefix . 'flights.flight_number as number,
+' . dbPrefix . 'flights.flight_type as type,
+' . dbPrefix . 'flights.dpt_airport_id as departureAirport,
+' . dbPrefix . 'flights.arr_airport_id as arrivalAirport,
+' . dbPrefix . 'flights.route,
+' . dbPrefix . 'flights.level as flightLevel,
+' . dbPrefix . 'flights.distance,
+' . dbPrefix . 'flights.dpt_time as departureTime,
+' . dbPrefix . 'flights.arr_time as arrivalTime,
+' . dbPrefix . 'flights.flight_time as flightTime,
+' . dbPrefix . 'flights.days as daysOfWeek,
+' . dbPrefix . 'flights.id as flightID,
+' . dbPrefix . 'flights.notes FROM ' . dbPrefix . 'bids INNER JOIN ' . dbPrefix . 'flights ON ' . dbPrefix . 'bids.flight_id = ' . dbPrefix . 'flights.id INNER JOIN ' . dbPrefix . 'airlines ON ' . dbPrefix . 'flights.airline_id = ' . dbPrefix . 'airlines.id WHERE ' . dbPrefix . 'bids.user_id=?',
 array($pilotID)
 );
 $aircraft = $database->fetch(
@@ -82,10 +82,10 @@ foreach($schedules as $idx=>$schedule) {
     }
 
     $subfleet = $database->fetch(
-        'SELECT DISTINCT aircraft.id as id  FROM ' . dbPrefix . 'aircraft
+        'SELECT DISTINCT ' . dbPrefix . 'aircraft.id as id  FROM ' . dbPrefix . 'aircraft
         LEFT JOIN ' . dbPrefix . 'flight_subfleet fs ON ' . dbPrefix . 'aircraft.subfleet_id = fs.subfleet_id
         WHERE fs.flight_id = ?
-        AND aircraft.status = ?',
+        AND ' . dbPrefix . 'aircraft.status = ?',
     array($schedule['flightID'], 'A'));
 
     foreach($subfleet as $aircraft) {

--- a/0.3.4/handlers/phpvms7/flights/search.php
+++ b/0.3.4/handlers/phpvms7/flights/search.php
@@ -1,25 +1,25 @@
 <?php
-$query = 'SELECT flights.id,
-airlines.icao as code,
-flights.flight_number as number,
-flights.flight_type as type,
-flights.dpt_airport_id as departureAirport,
-flights.arr_airport_id as arrivalAirport,
-flights.route,
-flights.level as flightLevel,
-flights.distance,
-flights.dpt_time as departureTime,
-flights.arr_time as arrivalTime,
-flights.flight_time as flightTime,
-flights.days as daysOfWeek,
-flights.notes FROM ' . dbPrefix . 'flights INNER JOIN ' . dbPrefix . 'airlines ON flights.airline_id = airlines.id';
+$query = 'SELECT ' . dbPrefix . 'flights.id,
+' . dbPrefix . 'airlines.icao as code,
+' . dbPrefix . 'flights.flight_number as number,
+' . dbPrefix . 'flights.flight_type as type,
+' . dbPrefix . 'flights.dpt_airport_id as departureAirport,
+' . dbPrefix . 'flights.arr_airport_id as arrivalAirport,
+' . dbPrefix . 'flights.route,
+' . dbPrefix . 'flights.level as flightLevel,
+' . dbPrefix . 'flights.distance,
+' . dbPrefix . 'flights.dpt_time as departureTime,
+' . dbPrefix . 'flights.arr_time as arrivalTime,
+' . dbPrefix . 'flights.flight_time as flightTime,
+' . dbPrefix . 'flights.days as daysOfWeek,
+' . dbPrefix . 'flights.notes FROM ' . dbPrefix . 'flights INNER JOIN ' . dbPrefix . 'airlines ON ' . dbPrefix . 'flights.airline_id = ' . dbPrefix . 'airlines.id';
 $parameters = array();
 
 if($_GET['aircraft'] !== null) {
     assertData($_GET, array('aircraft' => 'int'));
-    $subfleet = $database->fetch('SELECT s.id AS id FROM ' . dbPrefix . 'subfleets s LEFT JOIN ' . dbPrefix . ' aircraft a on a.subfleet_id = s.id WHERE a.id = ?', [$_GET['aircraft']]);
+    $subfleet = $database->fetch('SELECT s.id AS id FROM ' . dbPrefix . 'subfleets s LEFT JOIN ' . dbPrefix . 'aircraft a on a.subfleet_id = s.id WHERE a.id = ?', [$_GET['aircraft']]);
     $query .= ' INNER JOIN ' . dbPrefix . 'flight_subfleet fs ON flights.id = fs.flight_id WHERE fs.subfleet_id = :subfleetId';
-    
+
     if ($subfleet === array()) {
         echo (json_encode([]));
         return;
@@ -30,7 +30,7 @@ if($_GET['aircraft'] !== null) {
 
 if($_GET['departureAirport'] !== null) {
     assertData($_GET, array('departureAirport' => 'airport'));
-    $query .= ' WHERE flights.dpt_airport_id = :departureAirport';
+    $query .= ' WHERE ' . dbPrefix . 'flights.dpt_airport_id = :departureAirport';
     $parameters[':departureAirport'] = $_GET['departureAirport'];
 }
 if($_GET['arrivalAirport'] !== null) {
@@ -40,7 +40,7 @@ if($_GET['arrivalAirport'] !== null) {
     } else {
         $query .= ' AND ';
     }
-    $query .= 'flights.arr_airport_id = :arrivalAirport';
+    $query .= dbPrefix . 'flights.arr_airport_id = :arrivalAirport';
     $parameters[':arrivalAirport'] = $_GET['arrivalAirport'];
 }
 if($_GET['callsign'] !== null) {
@@ -50,7 +50,7 @@ if($_GET['callsign'] !== null) {
     } else {
         $query .= ' AND ';
     }
-    $query .= 'flights.callsign LIKE :callsign';
+    $query .= dbPrefix . 'flights.callsign LIKE :callsign';
     $parameters[':callsign'] = $_GET['callsign'];
 }
 if($_GET['minimumFlightTime'] !== null) {
@@ -60,7 +60,7 @@ if($_GET['minimumFlightTime'] !== null) {
     } else {
         $query .= ' AND ';
     }
-    $query .= 'flights.flight_time >= :minimumFlightTime';
+    $query .= dbPrefix . 'flights.flight_time >= :minimumFlightTime';
     $parameters[':minimumFlightTime'] = $_GET['minimumFlightTime'] * 60;
 }
 if($_GET['maximumFlightTime'] !== null) {
@@ -70,7 +70,7 @@ if($_GET['maximumFlightTime'] !== null) {
     } else {
         $query .= ' AND ';
     }
-    $query .= 'flights.flight_time <= :maximumFlightTime';
+    $query .= dbPrefix . 'flights.flight_time <= :maximumFlightTime';
     $parameters[':maximumFlightTime'] = $_GET['maximumFlightTime'] * 60;
 }
 if($_GET['minimumDistance'] !== null) {
@@ -80,7 +80,7 @@ if($_GET['minimumDistance'] !== null) {
     } else {
         $query .= ' AND ';
     }
-    $query .= 'flights.distance >= :minimumDistance';
+    $query .= dbPrefix . 'flights.distance >= :minimumDistance';
     $parameters[':minimumDistance'] = $_GET['minimumDistance'];
 }
 if($_GET['maximumDistance'] !== null) {
@@ -90,7 +90,7 @@ if($_GET['maximumDistance'] !== null) {
     } else {
         $query .= ' AND ';
     }
-    $query .= 'flights.distance <= :maximumDistance';
+    $query .= dbPrefix . 'flights.distance <= :maximumDistance';
     $parameters[':maximumDistance'] = $_GET['maximumDistance'];
 }
 
@@ -99,7 +99,7 @@ if($parameters === array()) {
 } else {
     $query .= ' AND ';
 }
-$query .= ' flights.active = 1 AND flights.visible = 1 ORDER BY flights.id DESC LIMIT 100';
+$query .= ' ' . dbPrefix . 'flights.active = 1 AND ' . dbPrefix . 'flights.visible = 1 ORDER BY ' . dbPrefix . 'flights.id DESC LIMIT 100';
 
 $results = $database->fetch($query, $parameters);
 $returns = array();
@@ -165,7 +165,7 @@ foreach($results as $index=>$result) {
     // Clone result index and create a copy for each aircraft
     $subfleets = $database->fetch(
         'SELECT DISTINCT type FROM ' . dbPrefix . 'subfleets
-        LEFT JOIN' . dbPrefix . ' flight_subfleet fs on' . dbPrefix . ' subfleets.id = fs.subfleet_id
+        LEFT JOIN ' . dbPrefix . 'flight_subfleet fs on ' . dbPrefix . 'subfleets.id = fs.subfleet_id
         WHERE fs.flight_id = ?',
     array($result['id']));
 

--- a/0.3.4/handlers/phpvms7/flights/update.php
+++ b/0.3.4/handlers/phpvms7/flights/update.php
@@ -53,7 +53,7 @@ function phaseToStatus(string $phase): string {
     }
 }
 
-$pirepID = $database->fetch('SELECT ' . dbPrefix . 'pireps.id FROM ' . dbPrefix . 'bids INNER JOIN ' . dbPrefix . 'pireps ON bids.flight_id = pireps.flight_id WHERE ' . dbPrefix . 'bids.id=? AND ' . dbPrefix . 'bids.user_id=?', array($_POST['bidID'], $pilotID));
+$pirepID = $database->fetch('SELECT ' . dbPrefix . 'pireps.id FROM ' . dbPrefix . 'bids INNER JOIN ' . dbPrefix . 'pireps ON ' . dbPrefix . 'bids.flight_id = ' . dbPrefix . 'pireps.flight_id WHERE ' . dbPrefix . 'bids.id=? AND ' . dbPrefix . 'bids.user_id=?', array($_POST['bidID'], $pilotID));
 if($pirepID === array())
 {
     $pirepID = substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 16);
@@ -66,18 +66,18 @@ if($pirepID === array())
     $flightID = $flightID[0]['flight_id'];
 
     $flightDetails = $database->fetch('SELECT ' .
-    dbPrefix . 'id as flight_id, ' .
-    dbPrefix . 'airline_id, ' .
-    dbPrefix . 'flight_number, ' .
-    dbPrefix . 'route_code, ' .
-    dbPrefix . 'route_leg, ' .
-    dbPrefix . 'flight_type, ' .
-    dbPrefix . 'dpt_airport_id, ' .
-    dbPrefix . 'arr_airport_id, ' .
-    dbPrefix . 'alt_airport_id, ' .
-    dbPrefix . 'level, ' .
-    dbPrefix . 'distance as planned_distance, ' .
-    dbPrefix . 'flight_time as planned_flight_time
+    'id as flight_id, ' .
+    'airline_id, ' .
+    'flight_number, ' .
+    'route_code, ' .
+    'route_leg, ' .
+    'flight_type, ' .
+    'dpt_airport_id, ' .
+    'arr_airport_id, ' .
+    'alt_airport_id, ' .
+    'level, ' .
+    'distance as planned_distance, ' .
+    'flight_time as planned_flight_time
     FROM ' . dbPrefix . 'flights WHERE id=?', array($flightID));
 
     if($flightDetails === array())

--- a/0.3.4/handlers/phpvms7/pireps/details.php
+++ b/0.3.4/handlers/phpvms7/pireps/details.php
@@ -11,7 +11,7 @@ $database->createTable('smartCARS3_FlightData', 'pilotID int(11) NOT NULL, pirep
 
 assertData($_GET, array('id'=>'string'));
 
-$comments = $database->fetch('SELECT comment FROM pirep_comments WHERE pirep_id=? AND user_id=? ORDER BY created_at DESC', array($_GET['id'], $pilotID));
+$comments = $database->fetch('SELECT comment FROM ' . dbPrefix . 'pirep_comments WHERE pirep_id=? AND user_id=? ORDER BY created_at DESC', array($_GET['id'], $pilotID));
 if($pirep === array())
 {
     error(404, 'A PIREP with this ID was not found');


### PR DESCRIPTION
This PR fixes a bug where the database prefix wasn't properly added to multiple SQL queries. As a result, phpVMS installations utilizing prefixed tables caused the API to consistently 500 error, thereby making smartCARS 3 unusable.

This has been tested on Spark Virtual's phpVMS 7 installation and has been verified to be functioning correctly with smartCARS 3 0.10.0.