### PR TITLE
fix: ignore pireps with status 4

### DIFF
--- a/0.3.5/handlers/phpvms7/pireps/search.php
+++ b/0.3.5/handlers/phpvms7/pireps/search.php
@@ -12,7 +12,7 @@ aircraft_id as aircraft,
 state as status,
 flight_time as flightTime,
 landing_rate as landingRate,
-fuel_used as fuelUsed FROM ' . dbPrefix . 'pireps WHERE user_id=:pilotid';
+fuel_used as fuelUsed FROM ' . dbPrefix . 'pireps WHERE user_id=:pilotid AND state != 4';
 $parameters = array(':pilotid' => $pilotID);
 
 if($_GET['departureAirport'] !== null)


### PR DESCRIPTION
In phpvms7 pireps with status 4 are cancelled and are missing data which breaks the logbook.

This happens if a user starts a flight and then decides to cancel it