### PR TITLE
[fix] Update PIREP state in update.php

### DIFF
--- a/0.3.5/handlers/phpvms7/flights/update.php
+++ b/0.3.5/handlers/phpvms7/flights/update.php
@@ -114,7 +114,7 @@ if($pirepID === array())
 else {
     $pirepID = $pirepID[0]['id'];
 }
-$database->execute('UPDATE ' . dbPrefix . 'pireps SET status=?, updated_at=NOW() WHERE id=?', array(phaseToStatus($_POST['phase']), $pirepID));
+$database->execute('UPDATE ' . dbPrefix . 'pireps SET state=1, status=?, updated_at=NOW() WHERE id=?', array(phaseToStatus($_POST['phase']), $pirepID));
 
 $database->execute('INSERT INTO ' . dbPrefix . 'acars
 (id, pirep_id, type, status, lat, lon, distance, heading, altitude, gs, created_at, updated_at)


### PR DESCRIPTION
Following scenario can happen:

- User bids and starts a flight
- Cancels the flight mid-journey
- Pirep gets cancelled, but in phpvms7 it is not removed from the database
- User tries to fly the same bid
- PIREP stays in "deleted" state in phpvms (state 4)