### PR TITLE
some updates for smartcars API for phpvms5

### DIFF
--- a/1.0.2/handlers/phpvms5/flights/search.php
+++ b/1.0.2/handlers/phpvms5/flights/search.php
@@ -18,7 +18,7 @@ notes FROM ' . dbPrefix . 'schedules';
 $whereInQuery = false;
 $parameters = array();
 
-if($_GET['departureAirport'] !== null)
+if(!empty($_GET['departureAirport']))
 {
     assertData($_GET, array('departureAirport' => 'airport'));
     if(!$whereInQuery)
@@ -29,7 +29,7 @@ if($_GET['departureAirport'] !== null)
     $query .= 'depicao = :departureAirport';
     $parameters[':departureAirport'] = $_GET['departureAirport'];
 }
-if($_GET['arrivalAirport'] !== null)
+if(!empty($_GET['arrivalAirport']))
 {
     assertData($_GET, array('arrivalAirport' => 'airport'));
     if(!$whereInQuery)
@@ -44,7 +44,7 @@ if($_GET['arrivalAirport'] !== null)
     $query .= 'arricao = :arrivalAirport';
     $parameters[':arrivalAirport'] = $_GET['arrivalAirport'];
 }
-if($_GET['aircraft'] !== null)
+if(!empty($_GET['aircraft']))
 {
     assertData($_GET, array('aircraft' => 'int'));
     if(!$whereInQuery)
@@ -59,7 +59,7 @@ if($_GET['aircraft'] !== null)
     $query .= 'aircraft IN (SELECT id FROM ' . dbPrefix . 'aircraft WHERE name LIKE (SELECT NAME from ' . dbPrefix . 'aircraft WHERE id = :aircraft))';
     $parameters[':aircraft'] = $_GET['aircraft'];
 }
-if($_GET['callsign'] !== null)
+if(!empty($_GET['callsign']))
 {
     assertData($_GET, array('callsign' => 'string'));
     if(!$whereInQuery)
@@ -74,7 +74,7 @@ if($_GET['callsign'] !== null)
     $query .= 'id IN (SELECT id FROM ' . dbPrefix . 'schedules WHERE CONCAT(code, flightnum) LIKE :callsign)';
     $parameters[':callsign'] = '%' . $_GET['callsign'] . '%';
 }
-if($_GET['minimumFlightTime'] !== null)
+if(!empty($_GET['minimumFlightTime']))
 {
     assertData($_GET, array('minimumFlightTime' => 'float'));
     if(!$whereInQuery)
@@ -89,7 +89,7 @@ if($_GET['minimumFlightTime'] !== null)
     $query .= 'CAST(flighttime AS DECIMAL(4,2)) >= :minimumFlightTime';
     $parameters[':minimumFlightTime'] = $_GET['minimumFlightTime'];
 }
-if($_GET['maximumFlightTime'] !== null)
+if(!empty($_GET['maximumFlightTime']))
 {
     assertData($_GET, array('maximumFlightTime' => 'float'));
     if(!$whereInQuery)
@@ -104,7 +104,7 @@ if($_GET['maximumFlightTime'] !== null)
     $query .= 'CAST(flighttime AS DECIMAL(4,2)) <= :maximumFlightTime';
     $parameters[':maximumFlightTime'] = $_GET['maximumFlightTime'];
 }
-if($_GET['minimumDistance'] !== null)
+if(!empty($_GET['minimumDistance']))
 {
     assertData($_GET, array('minimumDistance' => 'float'));
     if(!$whereInQuery)
@@ -119,7 +119,7 @@ if($_GET['minimumDistance'] !== null)
     $query .= 'distance >= :minimumDistance';
     $parameters[':minimumDistance'] = $_GET['minimumDistance'];
 }
-if($_GET['maximumDistance'] !== null)
+if(!empty($_GET['maximumDistance']))
 {
     assertData($_GET, array('maximumDistance' => 'float'));
     if(!$whereInQuery)
@@ -145,7 +145,7 @@ else
 }
 
 $limit = 100;
-if ($_GET['limit'] !== null) {
+if (!empty($_GET['limit'])) {
     assertData($_GET, array('limit' => 'int'));
     $limit = intval($_GET['limit']);
     $limit = $limit > 100 ? 100 : $limit;

--- a/1.0.2/handlers/phpvms5/flights/unbook.php
+++ b/1.0.2/handlers/phpvms5/flights/unbook.php
@@ -9,7 +9,7 @@ assertData($_POST, array('bidID'=>'int'));
 $bid = $database->fetch('SELECT routeid FROM ' . dbPrefix . 'bids WHERE pilotid=? AND bidid=?', array($pilotID, $_POST['bidID']));
 if($bid !== array())
 {
-    $flight = $database->fetch('SELECT id FROM ' . dbPrefix . 'schedules WHERE id=? AND enabled=0 AND notes="smartCARS Charter Flight"');
+    $flight = $database->fetch('SELECT id FROM ' . dbPrefix . 'schedules WHERE id=? AND enabled=0 AND notes="smartCARS Charter Flight"', array($bid['routeid']));
     if($flight !== array())
     {
         $database->execute('DELETE FROM ' . dbPrefix . 'schedules WHERE id=?', array($flight['id']));

--- a/1.0.2/handlers/phpvms5/flights/unbook.php
+++ b/1.0.2/handlers/phpvms5/flights/unbook.php
@@ -9,10 +9,10 @@ assertData($_POST, array('bidID'=>'int'));
 $bid = $database->fetch('SELECT routeid FROM ' . dbPrefix . 'bids WHERE pilotid=? AND bidid=?', array($pilotID, $_POST['bidID']));
 if($bid !== array())
 {
-    $flight = $database->fetch('SELECT id FROM ' . dbPrefix . 'schedules WHERE id=? AND enabled=0 AND notes="smartCARS Charter Flight"', array($bid['routeid']));
+    $flight = $database->fetch('SELECT id FROM ' . dbPrefix . 'schedules WHERE id=? AND enabled=0 AND notes="smartCARS Charter Flight"', array($bid[0]['routeid']));
     if($flight !== array())
     {
-        $database->execute('DELETE FROM ' . dbPrefix . 'schedules WHERE id=?', array($flight['id']));
+        $database->execute('DELETE FROM ' . dbPrefix . 'schedules WHERE id=?', array($flight[0]['id']));
     }
     $database->execute('DELETE FROM ' . dbPrefix . 'bids WHERE pilotid=? AND bidid=?', array($pilotID, $_POST['bidID']));
     $database->execute('DELETE FROM smartCARS3_BidAircraft WHERE bidid=?', array($_POST['bidID']));

--- a/1.0.2/handlers/phpvms5/pilot/login.php
+++ b/1.0.2/handlers/phpvms5/pilot/login.php
@@ -27,11 +27,11 @@ assertData($_POST, array('password' => 'string'));
 
 if(strpos($_GET['username'], '@'))
 {
-    $result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rankid, retired, confirmed, password, salt FROM ' . dbPrefix . 'pilots WHERE email=?', array($_GET['username']));
+    $result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rankid, ranklevel, retired, confirmed, password, salt FROM ' . dbPrefix . 'pilots WHERE email=?', array($_GET['username']));
 }
 else
 {
-    $result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rankid, retired, confirmed, password, salt FROM ' . dbPrefix . 'pilots WHERE pilotid=?', array($_GET['username']));
+    $result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rankid, ranklevel, retired, confirmed, password, salt FROM ' . dbPrefix . 'pilots WHERE pilotid=?', array($_GET['username']));
 }
 
 if($result === array())

--- a/1.0.2/handlers/phpvms5/pilot/resume.php
+++ b/1.0.2/handlers/phpvms5/pilot/resume.php
@@ -44,7 +44,7 @@ if(count($validSessions) === 0)
 {
     error(401, 'The session given was not valid');
 }
-$result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rankid FROM ' . dbPrefix . 'pilots WHERE pilotid=?', array($session[1]['sub']));
+$result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rankid, ranklevel FROM ' . dbPrefix . 'pilots WHERE pilotid=?', array($session[1]['sub']));
 if($result === array())
 {
     error(500, 'The session was found, but there was no valid pilot. Please report this to the VA');

--- a/1.0.2/handlers/phpvms5/pilot/verify.php
+++ b/1.0.2/handlers/phpvms5/pilot/verify.php
@@ -44,7 +44,7 @@ if(count($validSessions) === 0)
 {
     error(401, 'The session given was not valid');
 }
-$result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rankid FROM ' . dbPrefix . 'pilots WHERE pilotid=?', array($session[1]['sub']));
+$result = $database->fetch('SELECT code, pilotid, firstname, lastname, email, rankid, ranklevel FROM ' . dbPrefix . 'pilots WHERE pilotid=?', array($session[1]['sub']));
 if($result === array())
 {
     error(500, 'The session was found, but there was no valid pilot. Please report this to the VA');

--- a/1.0.2/handlers/phpvms5/pireps/search.php
+++ b/1.0.2/handlers/phpvms5/pireps/search.php
@@ -27,7 +27,6 @@ $status           = $_GET['status']           ?? null;
 $aircraftFilter   = $_GET['aircraft']         ?? null;
 
 if ($departureAirport !== null && $departureAirport !== '') {
-    // hier lieber mit einem eigenen Array prüfen, nicht mit ganz $_GET
     assertData(['departureAirport' => $departureAirport], ['departureAirport' => 'airport']);
     $query .= ' AND depicao = :departureAirport';
     $parameters[':departureAirport'] = $departureAirport;

--- a/1.0.2/handlers/phpvms5/pireps/search.php
+++ b/1.0.2/handlers/phpvms5/pireps/search.php
@@ -82,15 +82,16 @@ foreach($results as $index=>$result)
 {
     // Correct datetime to digit
     $ft = (string)$result['flightTime'];
-// if no decimal add ".00"
+    $ft = str_replace(':', '.', trim($ft));
+    // if no decimal add ".00"
     if (!str_contains($ft, '.')) {
         $ft .= '.00';
     }
-// Split
+    // Split
     list($hours, $minutesRaw) = explode('.', $ft);
-// calculate Minutes
+    // calculate Minutes
     $minutes = floatval(round($minutesRaw / 60, 2));
-// save result
+    // save result
     $results[$index]['flightTime'] = intval($hours) + $minutes;
     
     // Correct submission date format

--- a/1.0.2/handlers/phpvms5/pireps/search.php
+++ b/1.0.2/handlers/phpvms5/pireps/search.php
@@ -19,35 +19,42 @@ landingrate as landingRate,
 fuelused as fuelUsed FROM ' . dbPrefix . 'pireps WHERE pilotid=:pilotid';
 $parameters = array(':pilotid' => $pilotID);
 
-if($_GET['departureAirport'] !== null)
-{
-    assertData($_GET, array('departureAirport' => 'airport'));
+$departureAirport = $_GET['departureAirport'] ?? null;
+$arrivalAirport   = $_GET['arrivalAirport']   ?? null;
+$startDate        = $_GET['startDate']        ?? null;
+$endDate          = $_GET['endDate']          ?? null;
+$status           = $_GET['status']           ?? null;
+$aircraftFilter   = $_GET['aircraft']         ?? null;
+
+if ($departureAirport !== null && $departureAirport !== '') {
+    // hier lieber mit einem eigenen Array prüfen, nicht mit ganz $_GET
+    assertData(['departureAirport' => $departureAirport], ['departureAirport' => 'airport']);
     $query .= ' AND depicao = :departureAirport';
-    $parameters[':departureAirport'] = $_GET['departureAirport'];
+    $parameters[':departureAirport'] = $departureAirport;
 }
-if($_GET['arrivalAirport'] !== null)
-{
-    assertData($_GET, array('arrivalAirport' => 'airport'));
+
+if ($arrivalAirport !== null && $arrivalAirport !== '') {
+    assertData(['arrivalAirport' => $arrivalAirport], ['arrivalAirport' => 'airport']);
     $query .= ' AND arricao = :arrivalAirport';
-    $parameters[':arrivalAirport'] = $_GET['arrivalAirport'];
+    $parameters[':arrivalAirport'] = $arrivalAirport;
 }
-if($_GET['startDate'] !== null)
-{
-    assertData($_GET, array('startDate' => 'date'));
+
+if ($startDate !== null && $startDate !== '') {
+    assertData(['startDate' => $startDate], ['startDate' => 'date']);
     $query .= ' AND submitdate >= :startDate';
-    $parameters[':startDate'] = $_GET['startDate'];
+    $parameters[':startDate'] = $startDate;
 }
-if($_GET['endDate'] !== null)
-{
-    assertData($_GET, array('endDate' => 'date'));
+
+if ($endDate !== null && $endDate !== '') {
+    assertData(['endDate' => $endDate], ['endDate' => 'date']);
     $query .= ' AND submitdate <= DATE_ADD(:endDate, INTERVAL 1 DAY)';
-    $parameters[':endDate'] = $_GET['endDate'];
+    $parameters[':endDate'] = $endDate;
 }
-if($_GET['status'] !== null)
-{
-    assertData($_GET, array('status' => 'status'));
+
+if ($status !== null && $status !== '') {
+    assertData(['status' => $status], ['status' => 'status']);
     $query .= ' AND accepted = :status';
-    switch (strtolower($_GET['status'])) {
+    switch (strtolower($status)) {
         case 'accepted':
             $parameters[':status'] = 1;
             break;
@@ -57,23 +64,35 @@ if($_GET['status'] !== null)
         case 'rejected':
             $parameters[':status'] = 2;
             break;
+        default:
+            error(400, 'Invalid status value');
     }
 }
-if($_GET['aircraft'] !== null)
-{
-    assertData($_GET, array('aircraft' => 'int'));
+
+if ($aircraftFilter !== null && $aircraftFilter !== '') {
+    assertData(['aircraft' => $aircraftFilter], ['aircraft' => 'int']);
     $query .= ' AND aircraft = :aircraft';
-    $parameters[':aircraft'] = $_GET['aircraft'];
+    $parameters[':aircraft'] = $aircraftFilter;
 }
+
 $query .= ' ORDER BY submitdate DESC LIMIT 100';
 
 $results = $database->fetch($query, $parameters);
 foreach($results as $index=>$result)
 {
     // Correct datetime to digit
-    $flightTime = explode('.', $result['flightTime']);
-    $flightTime = intval($flightTime[0]) + floatval(round($flightTime[1] / 60, 2));
-    $results[$index]['flightTime'] = $flightTime;
+    $ft = (string)$result['flightTime'];
+// if no decimal add ".00"
+    if (!str_contains($ft, '.')) {
+        $ft .= '.00';
+    }
+// Split
+    list($hours, $minutesRaw) = explode('.', $ft);
+// calculate Minutes
+    $minutes = floatval(round($minutesRaw / 60, 2));
+// save result
+    $results[$index]['flightTime'] = intval($hours) + $minutes;
+    
     // Correct submission date format
     $results[$index]['submitDate'] = date(DATE_RFC3339, strtotime($result['submitDate']));
 


### PR DESCRIPTION
I fixed some small bugs in the API which came up, after I switched to PHP8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

### Added
- Added pilot `rankLevel` (integer) to PHPVMS5 pilot API responses (login, resume/profile, and verify).

### Fixed
- PHPVMS5 flight unbooking: fixed flight lookup and deletion logic (proper routeid binding and correct id access), preventing runtime errors.
- PHPVMS5 pilot verification: fixed result handling and ensured `rankLevel` is returned as an integer.
- PHPVMS5 PIREPS search: fixed flight-time parsing/normalization logic and added an explicit invalid-status path that returns HTTP 400.

### Changed
- PHPVMS5 PIREPS search: refactored query building to use validated local `$_GET` inputs (including improved empty/non-empty handling) and extended supported status handling (`accepted`, `pending`, `rejected`).
- PHPVMS5 flights search: broadened filter validation by switching from `null` checks to `empty()` checks for multiple query parameters (including limit).
- Minor formatting consistency (e.g., trailing newlines / closing PHP tag formatting) across the touched handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->